### PR TITLE
[bug 94] notification to client delayed in dfs put

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,9 @@ messages_files   = src/messages/boundaries.cc      \
                    src/messages/filedel.cc         \
                    src/messages/formatrequest.cc   \
                    src/messages/fileexist.cc       \
-                   src/messages/metadata.cc
+                   src/messages/metadata.cc        \
+                   src/messages/blockstatus.cc
+
 
 # libs -----
 lib_LTLIBRARIES     = libvdfs.la

--- a/src/messages/blockstatus.cc
+++ b/src/messages/blockstatus.cc
@@ -1,0 +1,5 @@
+#include "blockstatus.hh"
+
+using namespace eclipse::messages;
+
+std::string BlockStatus::get_type() const { return "BlockStatus"; }

--- a/src/messages/blockstatus.hh
+++ b/src/messages/blockstatus.hh
@@ -1,0 +1,17 @@
+#pragma once
+#include "message.hh"
+#include <cstdint>
+
+namespace eclipse {
+namespace messages {
+
+struct BlockStatus: public Message {
+  std::string get_type() const override;
+
+  std::string name;
+  uint32_t hash_key;
+  bool success = false;
+};
+
+}
+}

--- a/src/messages/boost_impl.cc
+++ b/src/messages/boost_impl.cc
@@ -193,6 +193,14 @@ template <typename Archive>
     ar & BOOST_SERIALIZATION_NVP(c.content);
   }
 
+template <typename Archive>
+  void serialize (Archive& ar, eclipse::messages::BlockStatus& c, unsigned int) {
+    ar & BASE_OBJECT(Message, c);
+    ar & BOOST_SERIALIZATION_NVP(c.name);
+    ar & BOOST_SERIALIZATION_NVP(c.hash_key);
+    ar & BOOST_SERIALIZATION_NVP(c.success);
+  }
+
 using namespace eclipse::messages;
 using namespace boost::archive;
 
@@ -306,6 +314,11 @@ template void serialize (boost::archive::xml_iarchive&,  MetaData&, unsigned);
 template void serialize (boost::archive::binary_iarchive&,  MetaData&, unsigned);
 template void serialize (boost::archive::binary_oarchive&,  MetaData&, unsigned);
 
+template void serialize (boost::archive::xml_oarchive&, BlockStatus&, unsigned);
+template void serialize (boost::archive::xml_iarchive&,  BlockStatus&, unsigned);
+template void serialize (boost::archive::binary_iarchive&,  BlockStatus&, unsigned);
+template void serialize (boost::archive::binary_oarchive&,  BlockStatus&, unsigned);
+
 }
 }
 
@@ -332,3 +345,4 @@ BOOST_CLASS_EXPORT_IMPLEMENT(eclipse::messages::BlockDel);
 BOOST_CLASS_EXPORT_IMPLEMENT(eclipse::messages::FormatRequest);
 BOOST_CLASS_EXPORT_IMPLEMENT(eclipse::messages::FileExist);
 BOOST_CLASS_EXPORT_IMPLEMENT(eclipse::messages::MetaData);
+BOOST_CLASS_EXPORT_IMPLEMENT(eclipse::messages::BlockStatus);

--- a/src/messages/boost_impl.hh
+++ b/src/messages/boost_impl.hh
@@ -28,6 +28,7 @@
 #include "blockupdate.hh"
 #include "fileupdate.hh"
 #include "metadata.hh"
+#include "blockstatus.hh"
 
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/tracking.hpp>
@@ -65,6 +66,7 @@ template <typename Archive> void serialize (Archive&, eclipse::messages::BlockDe
 template <typename Archive> void serialize (Archive&, eclipse::messages::FormatRequest&, unsigned);
 template <typename Archive> void serialize (Archive&, eclipse::messages::FileExist&, unsigned);
 template <typename Archive> void serialize (Archive&, eclipse::messages::MetaData&, unsigned);
+template <typename Archive> void serialize (Archive&, eclipse::messages::BlockStatus&, unsigned);
 }
 }
 
@@ -92,6 +94,7 @@ BOOST_CLASS_EXPORT_KEY(eclipse::messages::BlockDel);
 BOOST_CLASS_EXPORT_KEY(eclipse::messages::FormatRequest);
 BOOST_CLASS_EXPORT_KEY(eclipse::messages::FileExist);
 BOOST_CLASS_EXPORT_KEY(eclipse::messages::MetaData);
+BOOST_CLASS_EXPORT_KEY(eclipse::messages::BlockStatus);
 
 //! 4) and here
 BOOST_CLASS_TRACKING(eclipse::messages::Message, boost::serialization::track_never);
@@ -115,3 +118,4 @@ BOOST_CLASS_TRACKING(eclipse::messages::FileDel, boost::serialization::track_nev
 BOOST_CLASS_TRACKING(eclipse::messages::BlockDel, boost::serialization::track_never);
 BOOST_CLASS_TRACKING(eclipse::messages::FormatRequest, boost::serialization::track_never);
 BOOST_CLASS_TRACKING(eclipse::messages::FileExist, boost::serialization::track_never);
+BOOST_CLASS_TRACKING(eclipse::messages::BlockStatus, boost::serialization::track_never);

--- a/src/nodes/peerdfs.hh
+++ b/src/nodes/peerdfs.hh
@@ -38,8 +38,7 @@ class PeerDFS: public Node, public AsyncNode {
     virtual void update (uint32_t, std::string, std::string, uint32_t, uint32_t);
     virtual void request (uint32_t, std::string, req_func);
 
-    void close ();
-    bool insert_block (messages::BlockInfo*);
+    bool insert_block (messages::BlockInfo*, std::function<void(bool)>);
     bool update_block (messages::BlockUpdate*);
     bool insert_file (messages::FileInfo*);
     bool update_file (messages::FileUpdate*);
@@ -52,11 +51,13 @@ class PeerDFS: public Node, public AsyncNode {
 
   protected:
     void replicate_metadata();
+    void send_replicas(messages::BlockInfo*);
 
     Directory directory;
     Local_io local_io;
     std::unique_ptr<Histogram> boundaries;
     std::map<std::string, req_func> requested_blocks;
+    std::map<std::string, std::function<void(bool)>> insert_callback;
     int network_size;
 
     template <typename T> void process (T);

--- a/src/nodes/remotedfs.cc
+++ b/src/nodes/remotedfs.cc
@@ -30,18 +30,20 @@ RemoteDFS::RemoteDFS (PeerDFS* p, network::Network* net) : Router(net) {
 // BlockInfo {{{
 void RemoteDFS::insert_block (messages::Message* m_, int n_channel) {
   auto m = dynamic_cast<messages::BlockInfo*> (m_);
-  logger->info ("BlockInfo received");
-  bool ret = peer_dfs->insert_block(m);
-  Reply reply;
+  INFO("BlockInfo received");
 
-  if (ret) {
-    reply.message = "OK";
+  peer_dfs->insert_block(m, std::bind([=] (bool success) {
+        Reply reply;
 
-  } else {
-    reply.message = "FAIL";
-    reply.details = "Block already exists";
-  }
-  network->send(n_channel, &reply);
+        if (success) {
+          reply.message = "OK";
+
+        } else {
+          reply.message = "FAIL";
+          reply.details = "Block already exists";
+        }
+        network->send(n_channel, &reply);
+  }, ph::_1));
 }
 // }}}
 // BlockUpdate {{{


### PR DESCRIPTION
This PR Fixes DICL/EclipseMETA#94

## Status
- [x] Implemented
- [x] Compiles
- [x] Tested
- [x] Refactored
---

This patch fixes a long time bug in `dfs put` which prevent the client to be notified in time when the block has been finally copied to the remote server. 

It is linked as the a possible cause of many other bugs in uppers layers of the framework (MR)