### PR TITLE
bug fix for `ClientHandler::connect()`

### DIFF
--- a/src/network/client_handler.cc
+++ b/src/network/client_handler.cc
@@ -19,7 +19,7 @@ ClientHandler::ClientHandler (uint32_t p):
 // }}}
 // connect {{{
 void ClientHandler::connect(uint32_t i, shared_ptr<Server> server) {
-  spawn(context.io, [&, node=nodes[i], p=this->port](boost::asio::yield_context yield) {
+  spawn(context.io, [&, node=nodes[i], p=this->port, i, server](boost::asio::yield_context yield) {
       shared_ptr<Server> s = server;
       boost::system::error_code ec;
       tcp::resolver resolver (context.io);


### PR DESCRIPTION
In function `ClientHandler::connect(uint32_t i, shared_ptr<Server> server)`, `spawn()` doesn't capture the paremters of the caller, which leads to segmentation fault.

This PR Fixes DICL/EclipseMETA#(Which issue?)

## BRIEF
 
## STATUS
- [ ] Its implemented.
- [ ] It compiles.
- [ ] Its tested.
- [ ] Its refactored.

---
Make sure that you squeeze all your commits before merging to master.
You might want to use the following command:

    $ git rebase -i #hash key of base commit     

---
## EXTRA
