### PR TITLE
refactor work in localIO class

### DIFF
--- a/src/blocknode/local_io.cc
+++ b/src/blocknode/local_io.cc
@@ -69,7 +69,6 @@ std::string Local_io::read_metadata() {
   string value ((std::istreambuf_iterator<char>(in)),
       std::istreambuf_iterator<char>());
 
-  in.close();
   return value;
 }
 // }}}
@@ -92,13 +91,13 @@ bool Local_io::format () {
 
   DIR *theFolder = opendir(fs_path.c_str());
   struct dirent *next_file;
-  char filepath[257] = {0};
+  char filepath[FILENAME_MAX] = {0};
 
   while ( (next_file = readdir(theFolder)) != NULL ) {
-    sprintf(filepath, "%s/%s", fs_path.c_str(), next_file->d_name);
-    if (strncmp(basename(filepath), "..", 256) == 0 or
-        strncmp(basename(filepath), "...", 256) == 0 or
-        strncmp(basename(filepath), ".", 256) == 0)
+    snprintf(filepath, FILENAME_MAX, "%s/%s", fs_path.c_str(), next_file->d_name);
+    if (strncmp(basename(filepath), "..", FILENAME_MAX) == 0 or
+        strncmp(basename(filepath), "...", FILENAME_MAX) == 0 or
+        strncmp(basename(filepath), ".", FILENAME_MAX) == 0)
       continue;
 
     DEBUG("FORMAT: Removing %s", filepath);

--- a/src/blocknode/local_io.cc
+++ b/src/blocknode/local_io.cc
@@ -16,7 +16,7 @@ Local_io::Local_io() {
 //  }}}
 // write {{{
 //! @brief Unbuffered write to disk
-void Local_io::write (std::string name, std::string& v) {
+void Local_io::write (const std::string& name, const std::string& v) {
   string file_path = disk_path + string("/") + name;
   ofstream file;
 
@@ -27,7 +27,7 @@ void Local_io::write (std::string name, std::string& v) {
 }
 // }}}
 // update {{{
-void Local_io::update (std::string name, std::string v, uint32_t pos, uint32_t len) {
+void Local_io::update (const std::string& name, const std::string& v, uint32_t pos, uint32_t len) {
   string file_path = disk_path + string("/") + name;
   fstream file (file_path, fstream::binary | fstream::in | fstream::out);
   file.seekp(pos, ios_base::beg);
@@ -36,15 +36,15 @@ void Local_io::update (std::string name, std::string v, uint32_t pos, uint32_t l
 }
 // }}}
 // read {{{
-std::string Local_io::read (string name) {
+std::string Local_io::read (const string& name) {
   return read(name, 0, 0, true);
 }
 
-std::string Local_io::read (string name, uint32_t off, uint32_t len) {
+std::string Local_io::read (const string& name, uint32_t off, uint32_t len) {
   return read(name, off, len, false);
 }
 
-std::string Local_io::read (string name, uint32_t off, uint32_t len, bool is_whole = false) {
+std::string Local_io::read (const string& name, uint32_t off, uint32_t len, bool is_whole = false) {
   ifstream in (disk_path + string("/") + name, ios::in | ios::binary | ios::ate);
   uint32_t file_size = (uint32_t)in.tellg();
   in.seekg(off, ios::beg);
@@ -74,7 +74,7 @@ std::string Local_io::read_metadata() {
 }
 // }}}
 // pread {{{
-std::string Local_io::pread (string name, uint32_t pos, uint32_t len) {
+std::string Local_io::pread (const string& name, uint32_t pos, uint32_t len) {
   ifstream in (disk_path + string("/") + name);
   in.seekg(pos, in.beg);
   char *buffer = new char[len];
@@ -92,7 +92,7 @@ bool Local_io::format () {
 
   DIR *theFolder = opendir(fs_path.c_str());
   struct dirent *next_file;
-  char filepath[256] = {0};
+  char filepath[257] = {0};
 
   while ( (next_file = readdir(theFolder)) != NULL ) {
     sprintf(filepath, "%s/%s", fs_path.c_str(), next_file->d_name);
@@ -113,7 +113,7 @@ bool Local_io::format () {
 }
 // }}}
 // remove {{{
-void Local_io::remove (std::string k) {
+void Local_io::remove (const std::string& k) {
   string file_path = disk_path + string("/") + k;
   ::remove(file_path.c_str());
 }

--- a/src/blocknode/local_io.cc
+++ b/src/blocknode/local_io.cc
@@ -72,18 +72,6 @@ std::string Local_io::read_metadata() {
   return value;
 }
 // }}}
-// pread {{{
-std::string Local_io::pread (const string& name, uint32_t pos, uint32_t len) {
-  ifstream in (disk_path + string("/") + name);
-  in.seekg(pos, in.beg);
-  char *buffer = new char[len];
-  in.read(buffer, len);
-  string value(buffer);
-  delete[] buffer;
-  in.close();
-  return value;
-}
-// }}}
 // format {{{
 bool Local_io::format () {
   string fs_path = context.settings.get<string>("path.scratch");

--- a/src/blocknode/local_io.hh
+++ b/src/blocknode/local_io.hh
@@ -16,7 +16,6 @@ class Local_io {
     std::string read(const std::string&, uint32_t, uint32_t);
     std::string read(const std::string&, uint32_t, uint32_t, bool);
     std::string read_metadata();
-    std::string pread(const std::string&, uint32_t, uint32_t);
     void remove(const std::string&);
     bool format();
 

--- a/src/blocknode/local_io.hh
+++ b/src/blocknode/local_io.hh
@@ -10,14 +10,14 @@ namespace eclipse {
  */
 class Local_io {
   public:
-    void write(std::string, std::string&);
-    void update(std::string, std::string, uint32_t, uint32_t);
-    std::string read(std::string);
-    std::string read(std::string, uint32_t, uint32_t);
-    std::string read(std::string, uint32_t, uint32_t, bool);
+    void write(const std::string&, const std::string&);
+    void update(const std::string&, const std::string&, uint32_t, uint32_t);
+    std::string read(const std::string&);
+    std::string read(const std::string&, uint32_t, uint32_t);
+    std::string read(const std::string&, uint32_t, uint32_t, bool);
     std::string read_metadata();
-    std::string pread(std::string, uint32_t, uint32_t);
-    void remove(std::string);
+    std::string pread(const std::string&, uint32_t, uint32_t);
+    void remove(const std::string&);
     bool format();
 
     Local_io();


### PR DESCRIPTION
This PR Fixes DICL/EclipseMETA#142


## BRIEF
class LocalIO: switch to const& to evade expensive copying. Removes deprecated `pread` function. Uses standard FILEPATH_LEN for format.

## STATUS
- [x] Its implemented.
- [x] It compiles.
- [x] Its tested.
- [ ] Its refactored.

---
Make sure that you squeeze all your commits before merging to master.
You might want to use the following command:

    $ git rebase -i #hash key of base commit     

---

- This pull request will release: 1.8.5
